### PR TITLE
correction and cleaning of execution part with ensuring moving to nex…

### DIFF
--- a/EXECUTION/exe_builtin_cmd_1.c
+++ b/EXECUTION/exe_builtin_cmd_1.c
@@ -2,21 +2,23 @@
 
 void    cmd_exit(t_msh *msh)
 {
-	exit_cleanup("User says 'Be Gone Thot!'", msh, 0);
+	msh->exit_parent = 1;
+	exit_cleanup(NULL, msh, 0, 1);
 }
 
 void    cmd_echo(t_msh *msh)
 {
 	if (msh->pexe->next == NULL)
 		write(msh->fd[1], '\n', 1);
-	else if (msh->pexe->next->group_id == msh->pexe->group_id)
+	else if (msh->pexe->next != NULL\
+				&& msh->pexe->next->group_id == msh->pexe->group_id)
 	{
-		if (msh->pexe->next->type == STR && msh->pexe->next->cmd != NULL\
+		if (msh->pexe->next->cmd != NULL\
 			&& msh->pexe->next->p_index == (msh->pexe->p_index) + 1)
 		{
 			msh->pexe = msh->pexe->next;
-			if (ft_strlen(msh->pexe->option[1]) == 2\
-				&& !ft_strncmp("-n", msh->pexe->option[1], 2))
+			if (ft_strlen(msh->pexe->prev->option[1]) == 2\
+				&& !ft_strncmp("-n", msh->pexe->prev->option[1], 2))
 				ft_putstr_fd(msh->pexe->cmd, msh->fd[1]);
 			else
 			{
@@ -25,6 +27,8 @@ void    cmd_echo(t_msh *msh)
 			}
 		}
 	}
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
 }
 
 void	cmd_pwd(t_msh *msh)
@@ -37,16 +41,18 @@ void	cmd_pwd(t_msh *msh)
 	}
 	else
 		perror("Error printing current directoy");
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
 }
 
 void	cmd_cd(t_msh *msh) // absolute path is ok but need adding the relative path
 {
 	int	temp;
 
-	if (msh->pexe->next->group_id == msh->pexe->group_id)
+	if (msh->pexe->next != NULL\
+		&& msh->pexe->next->group_id == msh->pexe->group_id)
 	{
-		if (msh->pexe->next != NULL && msh->pexe->next->type == 3\
-			&& msh->pexe->next->cmd != NULL\
+		if (msh->pexe->next->type == PATH && msh->pexe->next->cmd != NULL\
 			&& access(msh->pexe->next->cmd, F_OK) == 0)
 		{
 			msh->pexe = msh->pexe->next;
@@ -56,10 +62,23 @@ void	cmd_cd(t_msh *msh) // absolute path is ok but need adding the relative path
 				if (temp == 1)
 					ft_printf("ok"); // to change for return as ok is to check if it is working correctly
 				else
-					ft_printf("You don't have permission to access this directory\n");
+					exit_cleanup("Permission denied\n", msh, code access, 0);
 			}
 			else
 				ft_printf("The directory %s doesn't exist\n", msh->pexe->cmd);
 		}
 	}
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
+}
+
+void	cmd_env(t_msh *msh) // to test
+{
+	int	i;
+
+	i = 0; //calling the array that keep env var in main
+	while (msh->envp[i] != NULL)
+		ft_putstr_fd(msh->envp[i++], msh->fd[1]);
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
 }

--- a/EXECUTION/exe_builtin_cmd_2.c
+++ b/EXECUTION/exe_builtin_cmd_2.c
@@ -1,72 +1,23 @@
 #include "../minishell.h"
 
-void	cmd_env(t_msh *msh) // to test
-{
-	int	i;
-
-	i = 0; //calling the array that keep env var in main
-	while (msh->envp[i] != NULL)
-		ft_putstr_fd(msh->envp[i++], msh->fd[1]);
-}
-
-void	adding_var(t_msh *msh, char *new_var)
-{
-	int		i;
-	int		envp_len;
-	char	**temp_envp;
-
-	envp_len = 0;
-	while (msh->envp[envp_len] != NULL) // getting the number of line in envp 
-			envp_len++;
-	temp_envp = malloc(sizeof(char *) * (envp_len + 2)); // malloc new structure + 2 for new line to add and NULL
-	if (temp_envp == NULL)
-		return ;
-	i = 0;
-	while (i < envp_len) //copying old array to new one
-	{
-		temp_envp[i] = msh->envp[i];
-		i++;
-	}
-	if (msh->envp != NULL) //free old array pointer
-		free(msh->envp);
-	msh->envp = temp_envp; //copying temp array ptr to envp on
-	msh->envp[i] = ft_strdup(new_var); //adding the line at the end with dup malloc
-	if (msh->envp[i] == NULL) 
-		ft_printf ("Error adding variable\n");
-}
-
-void	updating_var(t_msh *msh, char *var_to_update, int i)
-{
-	if (!ft_strncmp(msh->envp[i], msh->pexe->cmd[i], ft_strlen(msh->pexe->cmd[i])))
-		ft_memmove(var_to_update[i],msh->pexe->cmd[i], ft_strlen(msh->pexe->cmd[i]));
-}
-
 void	cmd_export(t_msh *msh) //adding variable to environmnet variable array
 {
 	char	*var_name;
 	int		j;
 
 	j = 0;
-	if (msh->pexe->next->group_id == msh->pexe->group_id)
+	if (msh->pexe->next != NULL\
+		&& msh->pexe->next->group_id == msh->pexe->group_id)
 	{
-		if (msh->pexe->next != NULL && msh->pexe->next->type == 2\
-			&& msh->pexe->next->cmd != NULL)
+		if (msh->pexe->next->p_index == 1 && msh->pexe->next->cmd != NULL)
 		{
 			msh->pexe = msh->pexe->next;
-			while (msh->pexe->cmd[j] != '=') // save the variable name to var_name str by cpy char until finding '='
-			{
-				var_name[j] = msh->pexe->cmd[j];
-				j++;
-			}
-			j = 0;
-			while (msh->envp[j] != NULL) //looping through evp to find the var_name 
-			{
-				if (!ft_strncmp(msh->envp[j], var_name, ft_strlen(var_name))) //if already existing --> return 
-					updating_var(msh, msh->envp[j], j);
-			}
-			adding_var(msh, var_name);
+			if (updating_var(msh->envp, var_name, msh->pexe->cmd[j]) == 0)
+				adding_var(msh, msh->pexe->cmd, msh->envp);
 		}
 	}
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
 }
 
 void	remove_var(t_msh *msh, char	*var_name)
@@ -96,10 +47,10 @@ void	cmd_unset(t_msh *msh, int i)
 	int		j;
 
 	j = 0;
-	if (msh->pexe->next->group_id == msh->pexe->group_id)
+	if (msh->pexe->next != NULL\
+		&& msh->pexe->next->group_id == msh->pexe->group_id)
 	{
-		if (msh->pexe->next != NULL && msh->pexe->next->type == 2\
-			&& msh->pexe->next->cmd != NULL)
+		if (msh->pexe->next->cmd != NULL)
 		{
 			msh->pexe = msh->pexe->next;
 			while (msh->pexe->cmd[j] != '=') // save the variable name to var_name str by cpy char until finding '='
@@ -110,4 +61,6 @@ void	cmd_unset(t_msh *msh, int i)
 			remove_var(msh, var_name);
 		}
 	}
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;
 }

--- a/EXECUTION/exe_define_signals.c
+++ b/EXECUTION/exe_define_signals.c
@@ -1,28 +1,35 @@
 #include "../minishell.h"
 
-void	sigint(t_msh *msh) //!!!! Buffer has to be discard as well
+void	sigint(t_msh *msh)
 {
 	ft_printf("\n");
-	free_pexe(msh);
-	free_parse(msh);
+	cleanup(msh);
+	msh = malloc(sizeof(t_msh));
+	if (msh == NULL)
+		exit_message("Allocation failed\n", 4);
 	minishell(msh);
 }
 
 void	sigeof(t_msh *msh)
 {
-	if (msh->input == NULL)
-		exit_cleanup("", msh, errno);
-	else if (msh->input != NULL)//prompt in work)
-		return ;
-	else if (msh->pexe != NULL)//prompt in work but time running is too long)
+	if (msh->input == NULL) // nothing in prompt
 	{
-		free_pexe(msh);
-		free_parse(msh);
+		cleanup(msh);
+		exit_message("SIGEOF\n", 20);
+	}
+	else if (msh->input != NULL)//prompt in work but not validated by user
+		return ;
+	else if (msh->pexe != NULL)//prompt in work and pexe initialized
+	{
+		cleanup(msh);
+		msh = malloc(sizeof(t_msh));
+		if (msh == NULL)
+			exit_message("Allocation failed\n", 4);
 		minishell(msh);
 	}
 }
 
-void	sigquit(t_msh *msh) //sigeof should never do something
+void	sigquit(t_msh *msh) //sigquit should never do something
 {
 	return ;
 }

--- a/EXECUTION/exe_executable.c
+++ b/EXECUTION/exe_executable.c
@@ -15,7 +15,7 @@ int	node_strlen(t_pexe *node)
 	return (len);
 }
 
-int	append_args(t_msh *msh)
+int	append_args(t_msh *msh) // to check in terms of malloc and free temp_option pointers
 {
 	int		i;
 	int 	len_g;
@@ -64,4 +64,6 @@ void	find_exe(t_msh *msh, char *cmd)
 			//exit error cleanup to add
 		}
 	}
+	while (msh->pexe->group_id != msh->pexe->group_id++)
+		msh->pexe = msh->pexe->next;	
 }

--- a/EXECUTION/exe_handle_signals.c
+++ b/EXECUTION/exe_handle_signals.c
@@ -29,7 +29,7 @@ void	signals_handler(int sig)
 		signal_flags |= SIGEOF_FLAG;
 }
 
-void	signal_handler_init()
+void	signal_handler_init(t_msh *msh)
 {
 	struct sigaction	sa;
 
@@ -40,8 +40,7 @@ void	signal_handler_init()
 		|| sigaction(EOF, &sa, NULL) == -1
 		|| sigaction(SIGQUIT, &sa, NULL) == -1)
 	{
-		ft_printf("Error handling the signal\n");
-		//add exit error code
-		exit(EXIT_FAILURE);
+		cleanup(msh);
+		exit_message("Error handling the signal\n", 6);
 	} 
 }

--- a/EXECUTION/exe_main.c
+++ b/EXECUTION/exe_main.c
@@ -1,10 +1,12 @@
 #include "../minishell.h"
 
-// void	check_exit_status_cmd(t_msh *msh, char *cmd)
-// {
-// 	if (ft_strlen(cmd) == 2 && !ft_strncmp("$?", cmd, 2))
-// 		cmd_exit_status(msh);
-// }
+void	check_exit_status_cmd(t_msh *msh, char *cmd)
+{
+	if (ft_strlen(cmd) == 2 && !ft_strncmp("$?", cmd, 2))
+	{
+		ft_printf("%d\n", msh->exit_error);
+	}
+}
 
 void	check_builtin_cmd(t_msh *msh, char *cmd)
 {
@@ -36,8 +38,14 @@ void	check_type(t_msh *msh)
 		find_exe(msh, msh->pexe->cmd);
 	else if (msh->pexe->type == EXIT_ERROR)
 		check_exit_status_cmd(msh, msh->pexe->cmd);
-	else if (msh->pexe->type == RED)
-		check_redirection(msh, msh->pexe->cmd);
+	else if (msh->pexe->type == INFILE)
+		red_left(msh); // pexe->cmd has the filename
+	else if (msh->pexe->type == OUTFILE)
+		red_right(msh); // pexe->cmd has the filename
+	else if (msh->pexe->type == APPEND)
+		double_red_right(msh); //pexe->cmd is filename
+	else if (msh->pexe->type == HEREDOC)
+		//function to pass the filename in option
 }
 
 int	execution(t_msh *msh)
@@ -48,17 +56,16 @@ int	execution(t_msh *msh)
 
 	i = 0;
 	p = 0;
-	msh->fd[0] = STDIN_FILENO;
-	msh->fd[1] = STDOUT_FILENO;
 	if (msh->pexe == NULL)
 		return (0);
-	g = msh->pexe->group_id;
-	while (msh->pexe != NULL)
-	{
-		check_type(msh);
-		if (msh->pexe->next != NULL)
-			msh->pexe = msh->pexe->next;
-		free_pexe(msh);
-	}
+	if (msh->pexe->group_id != 0)
+		msh->pexe = msh->pexe->next;
+	// while (msh->pexe != NULL && g = msh->pexe->group_id)
+	// {
+	check_type(msh);
+		// if (msh->pexe->next != NULL) to check!!!!
+		// 	msh->pexe = msh->pexe->next;
+		// free_pexe(msh);
+	// }
 	return (0);
 }

--- a/EXECUTION/exe_pipe.c
+++ b/EXECUTION/exe_pipe.c
@@ -1,12 +1,5 @@
 #include "../minishell.h"
 
-void	initialize_chds(t_pipex *chds)
-{
-	chds->fd[0] = STDIN_FILENO;
-	chds->fd[1] = STDOUT_FILENO;
-	chds->pid = -1;
-}
-
 void	pipex(t_msh *msh)
 {
 	int		i;
@@ -19,16 +12,20 @@ void	pipex(t_msh *msh)
 	{
 		chds[i] = (t_pipex *)malloc(sizeof(t_pipex));
 		if (chds[i] == NULL) //add the freeing to all the pointer in the array if error
-			return -1;
-		initialize_chds(chds[i++]);
+		{
+			free_pipex(chds);
+			exit_cleanup("Error handling pipe\n", msh, 1, 0);
+			return ;
+		}
+		clean_init_chds(chds[i++]);
 		msh->pipe_nb--;
 	}
-	while (j < (i - 1)) // while j is < to nb of chds minus 1 for the extra i++ at the end of the loop
+	while (j < i) // while j is < to nb of chds minus 1 for the extra i++ at the end of the loop
 		pipe(chds[j++]->fd);
 	chd1_fork(msh, chds[0]);
 	j = 1;
 	while (j < i)
 		mdlchd_fork(msh, chds[i - 1], chds[i++]);
-	lstchd_fork(msh, chds[i - 2], chds[i]);// check if i -1 or i - 2
-	closing(msh, chds, (i - 1)); //parent wait the children and close everything + total cleanup
+	lstchd_fork(msh, chds[i - 1], chds[i]);// check if i -1 or i - 2
+	closing(msh, chds, i - 1); //parent wait the children and close everything + total cleanup
 }

--- a/EXECUTION/exe_redirection.c
+++ b/EXECUTION/exe_redirection.c
@@ -24,7 +24,7 @@ void	open_file_input(t_msh *msh)
 	if (msh->pexe->next != NULL\
 		&& msh->pexe->next->group_id == msh->pexe->group_id)
 	{
-		if (msh->pexe->next->type == 7 && msh->pexe->next->cmd != NULL)
+		if (msh->pexe->next->type == FILENAME && msh->pexe->next->cmd != NULL)
 		{
 			msh->pexe = msh->pexe->next;
 			msh->fd[0] = open(msh->pexe->cmd, O_RDONLY, 664);
@@ -78,18 +78,4 @@ void	red_right(t_msh *msh)
 		msh->fd[1] = 1;
 		dup2(save_sdtout, STDOUT_FILENO);
 	}
-}
-
-void	check_redirection(t_msh *msh, char *cmd)
-{
-	if (ft_strlen(cmd) == 1 && !ft_strncmp("<", cmd, 1))
-		red_left(msh);
-	else if (ft_strlen(cmd) == 1 && !ft_strncmp(">", cmd, 1))
-		red_right(msh);
-	// else if (ft_strlen(cmd) == 2 && !ft_strncmp("<<", cmd, 2))
-	// 	double_red_left(msh);
-	else if (ft_strlen(cmd) == 2 && !ft_strncmp(">>", cmd, 2))
-		double_red_right(msh);
-	if (msh->pexe->next != NULL)
-		msh->pexe = msh->pexe->next;
 }

--- a/UTILS/clean_init.c
+++ b/UTILS/clean_init.c
@@ -6,11 +6,18 @@
 /*   By: mcoskune <mcoskune@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/10 18:43:14 by mcoskune          #+#    #+#             */
-/*   Updated: 2024/08/23 10:12:15 by mcoskune         ###   ########.fr       */
+/*   Updated: 2024/08/19 18:22:12 by mcoskune         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
 #include "../minishell.h"
+
+void	clean_init_chds(t_pipex *chds)
+{
+	chds->fd[0] = STDIN_FILENO;
+	chds->fd[1] = STDOUT_FILENO;
+	chds->pid = -1;
+}
 
 void	clean_init_pexe_node(t_pexe *pexe)
 {
@@ -35,10 +42,7 @@ void	clean_init_token_node(t_token *tkn)
 
 void	clean_init_parse(t_parse *pars)
 {
-	pars->modified = NULL;
-	pars->size_modified = -1;
-	pars->poi = NULL;
-	pars->here_fd = -1;
+	
 	pars->head = NULL;
 }
 
@@ -48,13 +52,24 @@ Function to set variables to their safe state. I.e. if a number is expected
 to be positive, init to -1 otherwise to 0. If there is a pointer, all are
 initialized to NULL. This is done to prevent derefencing an uninitialized func.
 */
-
-void	clean_initialize(t_msh *msh)
+void	clean_msh_init(t_msh *msh)
 {
-	if (msh == NULL)
-		exit_cleanup("Passed NULL to clean_init", NULL, errno);
-	
-	msh->input = NULL;
+	msh->input =  NULL;
+	msh->envp = NULL;
+	msh->fd[0] = STDIN_FILENO;
+	msh->fd[1] = STDOUT_FILENO;
+	msh->pipe_nb = 0;
+	msh->flag = -1;
+	msh->exit_error = -1;
 	msh->parse = NULL;
-	msh->parent_str = NULL;
+	msh->pexe = NULL; 
+	msh->main_child = -1;	
 }
+
+// void	clean_initialize(t_msh *msh) //double with the clean_msh_init function 
+// {
+// 	if (msh == NULL)
+// 		exit_cleanup("Passed NULL to clean_init", NULL, errno);
+// 	msh->input = NULL; 
+// 	msh->parse = NULL;
+// }

--- a/UTILS/exit_cleanup.c
+++ b/UTILS/exit_cleanup.c
@@ -33,6 +33,21 @@ void	free_mallocs(void *s_ptr, void **d_ptr)
 	}
 }
 
+void	free_pipex(t_pipex **children)
+{
+	int	i;
+
+	i = 0;
+	if (children[i] != NULL)
+	{
+		free(children[i]);
+		children[i++] = NULL;
+	}
+	if (children != NULL)
+		free(children);
+	children = NULL;
+}
+
 void	free_pexe(t_msh *msh)
 {
 	t_pexe	*temp;
@@ -57,7 +72,7 @@ void	free_parse(t_msh *msh)
 		while (msh->parse->head != NULL)
 		{
 			if (temp->token != NULL)
-				free (temp->token);
+				free(temp->token);
 			temp = msh->parse->head->next;
 			free (msh->parse->head);
 			msh->parse->head = temp;
@@ -67,16 +82,17 @@ void	free_parse(t_msh *msh)
 	}
 }
 
-void	exit_cleanup(char *msg, t_msh *msh, int flag)
+void	exit_cleanup(char *msg, t_msh *msh, int flag, int check)
 {
-	if (flag != 0)
-		printf("Error\n");
+	if (msh->parse != NULL)
+		free_parse(msh);
+	if (msh->pexe != NULL)
+		free_pexe(msh);
+	if (msh != NULL)
+		free(msh);
+	msh = NULL;
 	if (msg != NULL)
 		printf("Program Termination Reason - %s\n", msg);
-	if (msh->input != NULL)
-		free(msh->input);
-	free_parse(msh);
-	free_pexe(msh);
-	//rl_clear_history();
-	exit(flag);
+	if (check == 1)
+		exit(flag);
 }

--- a/UTILS/input_validate.c
+++ b/UTILS/input_validate.c
@@ -12,10 +12,16 @@
 
 #include "../minishell.h"
 
-void	input_validate(int ac, char **envp)
+int	input_validate(int ac, char **envp)
 {
 	if (ac != 1)
+	{
 		exit_cleanup("Too many clowns for this party", NULL, errno);
+		return (-1);
+	}
 	if (envp == NULL || *envp == NULL)
+	{
 		exit_cleanup("Where is my ENVP!", NULL, errno);
+		return (-1);
+	}
 }

--- a/UTILS/utils.c
+++ b/UTILS/utils.c
@@ -1,0 +1,51 @@
+#include "../minishell.h"
+
+void	adding_var(t_msh *msh, char *new_var, char **env_struct)
+{
+	int		i;
+	int		envp_len;
+	char	**temp_envp;
+
+	envp_len = 0;
+	while (env_struct[envp_len] != NULL) // getting the number of line in envp 
+			envp_len++;
+	temp_envp = malloc(sizeof(char *) * (envp_len + 2)); // malloc new structure + 2 for new line to add and NULL
+	if (temp_envp == NULL)
+		return ;
+	temp_envp[envp_len + 2] = NULL;
+	i = 0;
+	while (i < envp_len) //copying old array to new one
+	{
+		temp_envp[i] = env_struct[i];
+		i++;
+	}
+	if (env_struct != NULL) //free old array pointer
+		free(env_struct);
+	env_struct = temp_envp; //copying temp array ptr to envp on
+	env_struct[i] = ft_strdup(new_var); //adding the line at the end with dup malloc
+	if (env_struct[i] == NULL) 
+		exit_cleanup("Error adding variable\n", msh, code error, 0);
+}
+
+int	updating_var(char **env_struct, char *var_name, char *cmd)
+{
+	int	i;
+
+	i = 0;
+    while (cmd[i] != '=') // save the variable name to var_name str by cpy char until finding '='
+	{
+		var_name[i] = cmd[i];
+		i++;
+	}
+    i = 0;
+	while (env_struct[i] != NULL) //looping through evp to find the var_name 
+	{
+		if (!ft_strncmp(env_struct[i], var_name, ft_strlen(var_name)))
+		{
+			ft_memmove(env_struct[i], cmd, ft_strlen(cmd));
+			return (1);
+		}
+		i++;
+	}
+	return (0);
+}

--- a/bis_minishell.c
+++ b/bis_minishell.c
@@ -15,28 +15,50 @@
 
 void	minishell(t_msh *msh, int ac, char **av, char **envp)
 {
-	//move structure in this function instead of main
-	input_validate(ac, envp);
-	clean_initialize(&msh);
+	if (input_validate(ac, envp) != 0)
+	{
+		exit_cleanup("invalid input\n", msh, 0, 1);
+		return ;
+	}
 	while (1)
 	{
 		signal_input();
 		msh->input = readline("Heart of Gold>> ");
 		if (msh->input == NULL)
 			exit_cleanup("Problem in user input", msh, errno);
-		add_history(msh->input);
-		check_if_exit(*msh);
-		if (parse_main(msh) == 0)
-			execution(msh);
-		free(msh->input);
-		msh->input = NULL;
+		msh->main_child = fork();
+		if (msh->main_child == 0)
+		{
+			add_history(msh->input);
+			check_if_exit(*msh);
+			if (parse_main(msh) == 0)
+				execution(msh);
+			free(msh->input);
+			msh->input = NULL;
+		}
+		else
+		{
+			wait(&msh->exit_error);
+			kill(msh->main_child, SIGKILL);
+			if (msh->exit_parent != 0)
+				exit_cleanup(NULL, msh, 0, 1);
+		}
 	}
 }
+
 int main(int ac, char **av, char **envp)
 {
-	t_msh	msh;
+	t_msh	*msh;
 
 	(void)av;
-	signal_handler_init();
-	minishell(&msh, ac, av, envp); //correct the pointer if needed
+	msh = malloc(sizeof(t_msh));
+	if (msh == NULL)
+	{
+		ft_printf("Error\n");
+		exit(EXIT_FAILURE);
+	}
+	clean_msh_init(msh);
+	signal_handler_init(msh);
+	minishell(msh, ac, av, envp); 
+	exit(EXIT_SUCCESS);
 }

--- a/minishell.h
+++ b/minishell.h
@@ -6,7 +6,7 @@
 /*   By: mcoskune <mcoskune@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2024/08/09 18:39:17 by mcoskune          #+#    #+#             */
-/*   Updated: 2024/08/23 12:16:13 by mcoskune         ###   ########.fr       */
+/*   Updated: 2024/08/20 14:43:20 by mcoskune         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -48,7 +48,6 @@ typedef struct s_pexe
 	char			**option;
 	int				group_id;
 	int				p_index;
-	int				*fd;
 	struct s_pexe	*prev;
 	struct s_pexe	*next;
 }	t_pexe;
@@ -56,39 +55,40 @@ typedef struct s_pexe
 typedef struct s_msh //master structure 'minishell'
 {
 	char		*input;
-	int			exit_code;
-	//char		**parsed_args; // needed for execution
 	char		**envp; // keep the array in the structure to be sure to print all env var if env builtin function is called?
-	int			*fd;
+	int			fd[2];
 	int			pipe_nb;
+	int			flag;
 	int			exit_error;
+	int			exit_parent;
 	t_parse		*parse;
 	t_pexe		*pexe; //args structure for execution
+	pid_t		main_child;
 }	t_msh;
 
 typedef enum e_type
 {
 	COMMAND,
-	STR,
+	STRING,
 	PATH,
 	EXE,
 	EXIT_ERROR,
-	RED,
 	PIPE,
-	FNAME,
+	FILENAME,
 	SIGNAL,
 	HEREDOC,
+	INFILE,
 	OUTFILE,
 	APPEND,
 };
 
-/***********TYPE_SUMMARY*********/
-/* 1. builtin command			*/
-/* 2. string					*/
-/* 3. path						*/
-/* 4. execution					*/
-/* 5. $?						*/
-/* 6. redirection				*/
+/***********ERROR_TYPE***********/
+/* 1. command not found			*/
+/* 2. SIGEOF					*/
+/* 3. syntax error?				*/
+/* 4. allocation error			*/
+/* 5. File/directory not found	*/
+/* 6. Signals error				*/
 /* 7. filename					*/
 /* 8. pipe						*/
 /* 9. signal					*/
@@ -120,7 +120,7 @@ void	find_exe(t_msh *msh, char *cmd);
 int		parse_main(t_msh *msh);
 void	parse_malloc(t_msh *msh, t_parse *prs);
 t_token	*token_malloc(t_msh *msh, t_parse *prs);
-t_pexe	*pexe_malloc(t_msh *msh, t_parse *prs);
+void	pexe_malloc(t_msh *msh, t_parse *prs);
 void	add_node(void **head, void *node, size_t next_off, size_t prev_off);
 void	parse_tokenize(t_msh *msh, t_parse *prs);
 void	expand_dollars(t_msh *msh, t_parse *pars, int flag);


### PR DESCRIPTION
- updating of execute main function to ensure correct moving from pexe nodes
- start exit cleaning function update to match requirement (exit for program crash -- not seeing by user vs. exit within program so use see it (ex. catt or file doesn't exit)
- change redirection function so type is sending to correct function instead of comparing the arrow chars.
TODO:
- correct pipe so it handle only 1 pipe without calling middle child function
- update redirection function so no fork is called but ensure correct reading of filename called during redirection
- kill the child in pipe handling and sending signal to parent + other child
- ensure signal are correctly handle within pipe system as well
- continue cleanup of exit function with status
- check append_args function inside exe function